### PR TITLE
Fix to get the new windows focus

### DIFF
--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -71,6 +71,9 @@ function M.handler(_, _, result, _, _, _)
         close_events = {"CursorMoved", "BufHidden", "InsertCharPre"}
     })
 
+    -- Get the focus
+    vim.api.nvim_set_current_win(winnr)
+
     if M._state.winnr ~= nil then return end
 
     -- update the window number here so that we can map escape to close even


### PR DESCRIPTION
When you trigger the HoverActions the new popup windows created has not the focus.